### PR TITLE
Remove matrix-project

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -16,6 +16,7 @@ timestamper:1.6
 throttle-concurrents:1.8.4
 slack:1.7
 m2release:0.14.0
+matrix-project:1.6
 port-allocator:1.8
 sonar:2.1
 description-setter:1.9

--- a/plugins.txt
+++ b/plugins.txt
@@ -16,7 +16,6 @@ timestamper:1.6
 throttle-concurrents:1.8.4
 slack:1.7
 m2release:0.14.0
-matrix-project:1.6
 port-allocator:1.8
 sonar:2.1
 description-setter:1.9

--- a/plugins.txt
+++ b/plugins.txt
@@ -16,7 +16,6 @@ timestamper:1.6
 throttle-concurrents:1.8.4
 slack:1.7
 m2release:0.14.0
-matrix-project:1.4
 port-allocator:1.8
 sonar:2.1
 description-setter:1.9


### PR DESCRIPTION
The default Jenkins installation contains a newer version of this plugin, so let's just skip this line completely.
